### PR TITLE
Don't error on docstyle detection when docstring is only description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [tanchan.doc_parse.as_slash_command][] no-longer errors when the callback's
   docstring is just the description and `doc_style` is [None][].
+- [tanjun.doc_parse.with_annotated_args][] now allows [None][] to be explicitly
+  passed to `doc_style` typing wise.
 
 ## [0.1.0] - 2022-12-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional `name` argument to [tanchan.docs_parse.as_slash_command][] which
   allows overriding the command's name.
 
+### Fixed
+- [tanchan.doc_parse.as_slash_command][] no-longer errors when the callback's
+  docstring is just the description and `doc_style` is [None][].
+
 ## [0.1.0] - 2022-12-02
 ### Added
 - An extension to [tanjun.annotations][] which allows for parsing slash command

--- a/tanchan/doc_parse.py
+++ b/tanchan/doc_parse.py
@@ -363,7 +363,7 @@ def with_annotated_args(command: _CommandUnionT, /) -> _CommandUnionT:
 
 @typing.overload
 def with_annotated_args(
-    *, doc_style: _DocStyleUnion = "numpy", follow_wrapped: bool = False
+    *, doc_style: typing.Optional[_DocStyleUnion] = None, follow_wrapped: bool = False
 ) -> collections.Callable[[_CommandUnionT], _CommandUnionT]:
     ...
 

--- a/tanchan/doc_parse.py
+++ b/tanchan/doc_parse.py
@@ -235,9 +235,8 @@ class _Descriptions:
 _GOOGLE_PATTERN = re.compile(r"(\w+).*:(.*)$")
 
 
-def _parse_google(doc_string: str, /) -> dict[str, str]:
+def _parse_google(lines: list[str], /) -> dict[str, str]:
     descriptions = _Descriptions(_GOOGLE_PATTERN)
-    lines = doc_string.splitlines()
     start_index: typing.Optional[int] = None
 
     for index, line in enumerate(lines):
@@ -262,9 +261,8 @@ def _dedent_lines(lines: list[str], /) -> collections.Iterable[str]:
     return (line.removeprefix(indent) for line in lines)
 
 
-def _parse_numpy(doc_string: str, /) -> dict[str, str]:
+def _parse_numpy(lines: list[str], /) -> dict[str, str]:
     descriptions = _Descriptions(_NUMPY_PATTERN)
-    lines = doc_string.splitlines()
     start_index: typing.Optional[int] = None
 
     for index, line in enumerate(lines):
@@ -295,11 +293,11 @@ def _parse_numpy(doc_string: str, /) -> dict[str, str]:
 _REST_PATTERN = re.compile(r"^:(\w+) (\w+):(.*)$")
 
 
-def _parse_rest(doc_string: str, /) -> dict[str, str]:
+def _parse_rest(lines: list[str], /) -> dict[str, str]:
     current_line: list[str] = []
     descriptions: dict[str, str] = {}
 
-    for line in doc_string.splitlines():
+    for line in lines:
         match = _REST_PATTERN.match(line)
         if not match:  # TODO: does this want to be indentation aware?
             current_line.append(line.strip())
@@ -319,7 +317,7 @@ def _parse_rest(doc_string: str, /) -> dict[str, str]:
 
 
 _DocStyleUnion = typing.Literal["google", "numpy", "reST"]
-_PARSERS: dict[_DocStyleUnion, collections.Callable[[str], dict[str, str]]] = {
+_PARSERS: dict[_DocStyleUnion, collections.Callable[[list[str]], dict[str, str]]] = {
     "google": _parse_google,
     "numpy": _parse_numpy,
     "reST": _parse_rest,
@@ -339,6 +337,10 @@ def _parse_descriptions(
     if not doc_string:
         raise ValueError("Callback has no doc string")
 
+    lines = doc_string.splitlines()[1:]
+    if not lines:
+        return {}
+
     if doc_style is None:
         for pattern, style in _MATCH_STYLE:
             if pattern.search(doc_string):
@@ -349,7 +351,7 @@ def _parse_descriptions(
             raise RuntimeError("Couldn't detect the docstring style")
 
     if parser := _PARSERS.get(doc_style):
-        return parser(doc_string)
+        return parser(lines)
 
     raise ValueError(f"Unsupported docstring style {doc_style!r}")
 

--- a/tests/test_doc_parse.py
+++ b/tests/test_doc_parse.py
@@ -40,16 +40,34 @@ import tanchan
 def test_when_cant_detect_doc_style():
     @tanchan.doc_parse.as_slash_command()
     async def command(ctx: tanjun.abc.Context) -> None:
-        """Description."""
+        """Description.
+
+        Not empty.
+        """
 
     with pytest.raises(RuntimeError, match="Couldn't detect the docstring style"):
         tanchan.doc_parse.with_annotated_args(command)
 
 
+def test_when_only_description_in_docstring():
+    @tanchan.doc_parse.with_annotated_args
+    @tanchan.doc_parse.as_slash_command()
+    async def aaaaaa_command(ctx: tanjun.abc.Context) -> None:
+        """Meow description."""
+
+    assert aaaaaa_command.name == aaaaaa_command.name == "aaaaaa_command"
+    assert aaaaaa_command.description == aaaaaa_command.description == "Meow description."
+
+    assert len(aaaaaa_command.build().options) == 0
+
+
 def test_when_invalid_doc_style_passed():
     @tanchan.doc_parse.as_slash_command()
     async def command(ctx: tanjun.abc.Context) -> None:
-        """Description."""
+        """Description.
+
+        Not empty.
+        """
 
     with pytest.raises(ValueError, match="Unsupported docstring style 'catgirl-ml'"):
         tanchan.doc_parse.with_annotated_args(doc_style="catgirl-ml")(command)  # type: ignore

--- a/tests/test_doc_parse.py
+++ b/tests/test_doc_parse.py
@@ -49,8 +49,9 @@ def test_when_cant_detect_doc_style():
         tanchan.doc_parse.with_annotated_args(command)
 
 
-def test_when_only_description_in_docstring():
-    @tanchan.doc_parse.with_annotated_args
+@pytest.mark.parametrize("doc_style", [None, "google", "numpy", "reST"])
+def test_when_only_description_in_docstring(doc_style: typing.Optional[typing.Literal["google", "numpy", "reST"]]):
+    @tanchan.doc_parse.with_annotated_args(doc_style=doc_style)
     @tanchan.doc_parse.as_slash_command()
     async def aaaaaa_command(ctx: tanjun.abc.Context) -> None:
         """Meow description."""
@@ -92,13 +93,16 @@ def test_as_slash_command_when_name_override_passed():
     assert builder.description == command.description == "Meow me meow."
 
 
-def test_with_annotated_args_when_has_no_doc_string():
+@pytest.mark.parametrize("doc_style", [None, "google", "numpy", "reST"])
+def test_with_annotated_args_when_has_no_doc_string(
+    doc_style: typing.Optional[typing.Literal["google", "numpy", "reST"]]
+):
     @tanjun.as_slash_command("name", "description")
     async def command(ctx: tanjun.abc.Context) -> None:
         ...
 
     with pytest.raises(ValueError, match="Callback has no doc string"):
-        tanchan.doc_parse.with_annotated_args()(command)
+        tanchan.doc_parse.with_annotated_args(doc_style=doc_style)(command)
 
 
 def test_google():


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
